### PR TITLE
macOS: Limit includes to CoreFoundation directory (due error with rec…

### DIFF
--- a/config/sysroot_macos_aarch64.BUILD
+++ b/config/sysroot_macos_aarch64.BUILD
@@ -53,7 +53,8 @@ cc_toolchain_import(
     name = "includes_system",
     hdrs = glob([
         "usr/include/**",
-        "System/Library/Frameworks/**",
+        "System/Library/Frameworks/CoreFoundation/**",                      # Include created symbolic link directory
+        "System/Library/Frameworks/CoreFoundation.framework/**",
     ]),
     includes = [
         "usr/include",


### PR DESCRIPTION
…ursive ruby symlink)